### PR TITLE
74 selecting levels with cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import ProtectedRoute from "./components/ProtectedRoute/index.tsx";
 import { useState } from "react";
 import { auth } from "./firebase/firebase.ts";
 import { User as FirebaseUser } from "firebase/auth";
+import { LevelContextProvider } from "./context/LevelContext.tsx";
+import LevelContextLayout from "./components/LevelContextLayout.tsx";
 
 function App() {
   const [user, setUser] = useState<FirebaseUser | null>(null);
@@ -29,22 +31,24 @@ function App() {
           <Route path="/" element={<LandingPage/>}/>
           <Route path="/login" element={<LoginPage/>}/>
           <Route path="/signup" element={<SignupPage/>}/>
-          <Route
-            path="/home"
-            element={
-              <ProtectedRoute user={user}>
-                <LevelSelectPage/>
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/question"
-            element={
-              <ProtectedRoute user={user}>
-                <QuestionPage/>
-              </ProtectedRoute>
-            }
-          />
+          <Route element={<LevelContextLayout />}>
+            <Route
+              path="/home"
+              element={
+                <ProtectedRoute user={user}>
+                  <LevelSelectPage/>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/question"
+              element={
+                <ProtectedRoute user={user}>
+                  <QuestionPage/>
+                </ProtectedRoute>
+              }
+            />
+          </Route>
         </Routes>
       </ThemeProvider>
   );

--- a/src/components/Frame.tsx
+++ b/src/components/Frame.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, CardProps, SxProps, styled } from "@mui/material";
-import { ReactElement, ReactPropTypes } from "react";
+import { ReactElement } from "react";
 
 const CardContentNoPadding = styled(CardContent)(`
   &:last-child {
@@ -12,9 +12,9 @@ interface Props extends CardProps {
   children?: ReactElement | ReactElement[]
 }
 
-export default function Frame({className, sx, children}: Props) {
+export default function Frame({sx, children, className, onClick}: Props) {
   return (
-    <Card className={className} sx={{
+    <Card className={className} onClick={onClick}  sx={{
       background: "background.paper",
       borderRadius: 2,
       color: "white",

--- a/src/components/LevelContextLayout.tsx
+++ b/src/components/LevelContextLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router-dom";
+import { LevelContextProvider } from "../context/LevelContext";
+
+export default function LevelContextLayout() {
+
+  return(
+    <LevelContextProvider>
+      <Outlet/>
+    </LevelContextProvider>
+  )
+}

--- a/src/components/LevelDescription/LevelDescription.tsx
+++ b/src/components/LevelDescription/LevelDescription.tsx
@@ -2,15 +2,15 @@ import { Box, Divider, Stack, Typography } from "@mui/material";
 import styles from "./LevelDescription.module.css";
 import { useNavigate } from "react-router-dom";
 import GreenButton from "../GreenButton/GreenButton";
+import { useContext } from "react";
+import { LevelContext } from "../../context/LevelContext";
 
-interface Props {
-  title: string;
-  content: string;
-}
 /*To go in the LevelSelectPage 
 <LevelDescription title='1. Commit and Push' content = '1. Sed luctus venenatis massa. Nam sagittis neque nec purus aliquam, a tempus velit hendrerit. Pellentesque ac risus aliquet, egestas orci vitae, feugiat tellus. 2. Morbi id tortor id enim consectetur consectetur. Praesent orci erat, consectetur quis efficitur pretium, auctor blandit lorem. Donec lobortis arcu ac dui luctus tincidunt. 3. Proin scelerisque arcu sapien, eu tristique lorem dictum eget. Suspendisse mollis tempor ligula nec iaculis. Quisque maximus interdum nunc, ut convallis quam pretium vitae. Duis posuere neque urna, id auctor arcu consectetur id. Ut mollis lectus tortor, eu tempus quam vestibulum at. Integer in leo non nisi scelerisque molestie. Nullam ut volutpat ante. 4. Duis ultrices erat urna, eu semper augue euismod eget. Nulla ac elit nunc. Mauris non diam quam. Nullam consectetur ipsum non metus blandit bibendum'/> */
-export default function LevelDescription({ title, content }: Props) {
+export default function LevelDescription() {
   const navigate = useNavigate();
+
+  const { selectedQuestion } = useContext(LevelContext);
 
   function startProblem() {
     // Any logic before starting problem
@@ -21,32 +21,17 @@ export default function LevelDescription({ title, content }: Props) {
   return (
     <Stack className={styles["container"]}>
       <Typography className={styles["title"]} variant="h2">
-        1. Commit and Push
-        {/*{title}*/}
+        {selectedQuestion.title}
       </Typography>
       <Typography className={styles["objectives-heading"]} variant="h3">
         Learning Objectives
       </Typography>
       <ul>
-        <li>
-          <Typography sx={{ textAlign: "left" }}>
-            Familiarity with Git Terminology: Students will become reacquainted
-            with essential Git terminology, including "commit," and "push."
-          </Typography>
-        </li>
-        <li>
-          <Typography sx={{ textAlign: "left" }}>
-            Committing Changes: Students will revisit how to create a commit in
-            Git
-          </Typography>
-        </li>
-        <li>
-          <Typography sx={{ textAlign: "left" }}>
-            Pushing Commits: Students will grasp the concept of pushing commits
-            to a remote repository, gaining knowledge about the purpose of
-            remotes and the git push command.
-          </Typography>
-        </li>
+        {selectedQuestion.learningObjective.outcomeArray.map((outcome, index) => (
+          <li key={index}>
+            <Typography sx={{ textAlign: "left" }}>{outcome}</Typography>
+          </li>
+        ))}
       </ul>
       <Divider className={styles["divider"]} variant="middle" />
       <Box sx={{ flexGrow: 1 }}></Box>

--- a/src/components/LevelDiscussion/LevelDiscussion.tsx
+++ b/src/components/LevelDiscussion/LevelDiscussion.tsx
@@ -8,17 +8,17 @@ import {
 } from "@mui/material";
 import ThumbUpIcon from "@mui/icons-material/ThumbUp";
 import styles from "./LevelDiscussion.module.css";
-import { Question } from "../../models/types.ts";
-import { useState } from "react";
+import { useContext, useState } from "react";
+import { LevelContext } from "../../context/LevelContext.tsx";
 
-interface Props {
-  question: Question;
-}
 
-export default function LevelDiscussion({ question }: Props) {
-  const discussion = question.discussion;
+export default function LevelDiscussion() {
+
+  const { selectedQuestion } = useContext(LevelContext);
+
   const [commentToSend, setCommentToSend] = useState<string>("");
 
+  // TODO: replace with DB call
   const [dummyComments, setDummyComments] = useState([
     {
       id: "1",
@@ -55,7 +55,7 @@ export default function LevelDiscussion({ question }: Props) {
       </Typography>
       <Stack>
         <Typography sx={{ textAlign: "left", py: 2 }}>
-          {discussion.statement}
+          {selectedQuestion.discussion.statement}
         </Typography>
         <Stack
           direction="column"
@@ -71,13 +71,13 @@ export default function LevelDiscussion({ question }: Props) {
             backgroundColor: "#1E1E1E",
           }}
         >
-          {discussion.commands.map((cmd) => (
+          {selectedQuestion.discussion.commands.map((cmd) => (
             <Typography sx={{ textAlign: "left" }} key={cmd}>
               {cmd}
             </Typography>
           ))}
         </Stack>
-        {discussion.answers.map((ans) => (
+        {selectedQuestion.discussion.answers.map((ans) => (
           <Stack key={ans.step} sx={{ py: 2 }}>
             <Typography sx={{ textAlign: "left", py: 2 }}>
               {ans.step}
@@ -92,6 +92,7 @@ export default function LevelDiscussion({ question }: Props) {
           </Stack>
         ))}
 
+        {/* Footer */}
         <Typography sx={{ textAlign: "left", py: 2 }}>
           For more information, Checkout Atlassian's Page{" "}
           <a href="https://www.atlassian.com/git/tutorials/learn-git-with-bitbucket-cloud">
@@ -101,6 +102,7 @@ export default function LevelDiscussion({ question }: Props) {
         <Typography variant="h3" sx={{ textAlign: "left", py: 2 }}>
           Post your answers below, Is there another way to get the solution?
         </Typography>
+
       </Stack>
 
       <Divider

--- a/src/context/LevelContext.tsx
+++ b/src/context/LevelContext.tsx
@@ -1,0 +1,36 @@
+import React, { ReactElement, useState } from 'react';
+import { Question } from '../models/types';
+import { DUMMY_DATA_QUESTIONS } from '../data/dummyData';
+
+export interface LevelContextType {
+  selectedQuestion: Question;
+  setQuestion: (question: Question) => void;
+}
+
+const LevelContext = React.createContext<LevelContextType>({} as LevelContextType);
+
+type Props = {
+  children: ReactElement | ReactElement[]
+}
+
+function LevelContextProvider({children}: Props) {
+  const [selectedQuestion, setSelectedQuestion] = useState<Question>(DUMMY_DATA_QUESTIONS[0]);
+
+  const setQuestion = (question: Question) => {
+    setSelectedQuestion(question);
+  };
+
+  return (
+    <LevelContext.Provider value={{
+      selectedQuestion,
+      setQuestion,
+    }}>
+      {children}
+    </LevelContext.Provider>
+  );
+}
+
+export {
+  LevelContext,
+  LevelContextProvider
+};

--- a/src/context/LevelContext.tsx
+++ b/src/context/LevelContext.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { Question } from '../models/types';
 import { DUMMY_DATA_QUESTIONS } from '../data/dummyData';
 
@@ -15,7 +15,7 @@ type Props = {
 
 function LevelContextProvider({children}: Props) {
   const [selectedQuestion, setSelectedQuestion] = useState<Question>(DUMMY_DATA_QUESTIONS[0]);
-
+  
   const setQuestion = (question: Question) => {
     setSelectedQuestion(question);
   };

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -1,4 +1,5 @@
 import { Graph, Question } from "../models/types.ts";
+import { Difficulty } from "../firebase/enums.ts";
 
 export const DUMMY_DATA_QUESTIONS: Question[] = [
   {
@@ -56,7 +57,13 @@ export const DUMMY_DATA_QUESTIONS: Question[] = [
     },
     // commentIds: [],
     initialGraph: null,
-    goalGraph: null
+    goalGraph: null,
+    difficulty: Difficulty.EASY,
+    tags: ["commit", "push"]
+  },
+  {
+    title: "Checkout and Branch",
+    // The rest of the info
   }
 ]
 
@@ -65,8 +72,8 @@ export const DUMMY_DATA_GRAPHS: Graph[] = [
     name: `${DUMMY_DATA_QUESTIONS[0].title} - Initial Graph`,
     nodes: ["C1", "C2", "C3"],
     edges: [
-      {source: "C1", target: "C2"},
-      {source: "C1", target: "C3"}
+      { source: "C1", target: "C2" },
+      { source: "C1", target: "C3" }
     ],
     headNode: "C1"
   },
@@ -74,8 +81,8 @@ export const DUMMY_DATA_GRAPHS: Graph[] = [
     name: `${DUMMY_DATA_QUESTIONS[0].title} - Goal Graph`,
     nodes: ["C1", "C2", "C3"],
     edges: [
-      {source: "C1", target: "C2"},
-      {source: "C1", target: "C3"}
+      { source: "C1", target: "C2" },
+      { source: "C1", target: "C3" }
     ],
     headNode: "C1"
   }

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -3,7 +3,68 @@ import { Graph, Question } from "../models/types.ts";
 
 export const DUMMY_DATA_QUESTIONS: Question[] = [
   {
+    id: "Commit and Push",
     title: "Commit and Push",
+    hints: [
+      "Once your changes are staged, it's time to commit them. Use the git commit command along with a descriptive commit message to document the purpose and nature of your changes. A well-written commit message is essential for clear communication within a development team.",
+      "After committing your changes locally, it's time to share them with others by pushing the commits to a remote repository. Use the git push command to send your changes to the designated remote repository, allowing others to access and integrate your work.",
+      "If you require further information, check out this git guide provided by Atlassian"
+    ],
+    summary: [
+      "You have successfully completed your first Git commit and push.",
+      "Take a moment to reflect on the importance of these actions in version control and collaborative development.",
+      "Remember, committing and pushing changes regularly helps maintain a reliable and traceable history of your project.",
+      "For more information, checkout the discussion page for this question"
+    ],
+    description: {
+      description: "Welcome to your first lesson on Git, the widely used version control system in the software development industry. In this lesson, we will delve into the fundamental concepts of Git commit and push, which form the backbone of collaborative code management.",
+      activityArray: [
+        "In this activity, we will guide you through the process of committing and pushing changes to a Git repository.",
+        "All changes have already been added and staged, now we need to commit and push our changes onto main.",
+      ]
+    },
+    learningObjective: {
+      objective: "By the end of this lesson, you will understand the importance of Git commit and push, and how they enable you to track and share changes in your codebase effectively.",
+      outcomeArray: [
+        "Familiarity with Git Terminology: Students will become reacquainted with essential Git terminology, including \"commit,\" and \"push.\"",
+        "Committing Changes: Students will revisit how to create a commit in Git.",
+        "Pushing Commits: Students will grasp the concept of pushing commits to a remote repository, gaining knowledge about the purpose of remotes and the git push command."
+      ]
+    },
+    discussion: {
+      statement: "To commit and push changes to a Git repository, you need to follow a series of commands. Let's go through each step, and then we'll provide explanations for each command:",
+      commands: [
+        "git commit -m \"Enter your commit message here\"",
+        "git push origin main"
+      ],
+      answers: [
+        {
+          step: "Step 1: Commit the Changes",
+          explanation: [
+            "Committing changes in Git is like taking a snapshot of your code at a specific point in time. It allows you to document the changes made and provide a clear description of the modifications",
+            "The -m flag stands for message and is followed by the commit message enclosed in quotes. The commit message is a brief description that explains what changes were made in the commit. It is important to provide a meaningful and descriptive commit message to help you and others understand the purpose of the commit.",
+          ]
+        },
+        {
+          step: "Step 2: Push the Commits",
+          explanation: [
+            "Once you have committed your changes, it's time to push them to a remote repository. Pushing commits means sending your committed changes to a shared repository that can be accessed by others. Use the command git push origin main to push your commits.",
+            "In this command, origin refers to the remote repository's name. You can replace it with the appropriate remote repository name if it differs. main represents the branch you are pushing to, which is typically the main branch in many Git workflows. However, if your repository uses a different main branch name (e.g., master), make sure to replace main with the correct branch name.",
+            "By executing git push origin main, you send your commits to the remote repository, making them available to others who have access to the repository. This allows for collaboration and synchronization of code changes among team members.",
+            "Remember, the git commit -m command and the git push origin main command are essential for documenting and sharing your code changes. By providing meaningful commit messages and regularly pushing your commits to the remote repository, you can effectively track and collaborate on your codebase."
+          ]
+        }
+      ]
+    },
+    // commentIds: [],
+    initialGraph: null,
+    goalGraph: null,
+    difficulty: Difficulty.EASY,
+    tags: [Tags.commit, Tags.push],
+  },
+  {
+    id: "Commit and TEshtalhfal",
+    title: "Commit and TEshtalhfal",
     hints: [
       "Once your changes are staged, it's time to commit them. Use the git commit command along with a descriptive commit message to document the purpose and nature of your changes. A well-written commit message is essential for clear communication within a development team.",
       "After committing your changes locally, it's time to share them with others by pushing the commits to a remote repository. Use the git push command to send your changes to the designated remote repository, allowing others to access and integrate your work.",

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -118,7 +118,7 @@ export const DUMMY_DATA_QUESTIONS: Question[] = [
     initialGraph: null,
     goalGraph: null,
     difficulty: Difficulty.MEDIUM,
-    tags: [Tags.commit, Tags.push],
+    tags: [Tags.checkout, Tags.branch],
   }
 ]
 

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -4,7 +4,7 @@ import { Graph, Question } from "../models/types.ts";
 export const DUMMY_DATA_QUESTIONS: Question[] = [
   {
     id: "Commit and Push",
-    title: "Commit and Push",
+    title: "1. Commit and Push",
     hints: [
       "Once your changes are staged, it's time to commit them. Use the git commit command along with a descriptive commit message to document the purpose and nature of your changes. A well-written commit message is essential for clear communication within a development team.",
       "After committing your changes locally, it's time to share them with others by pushing the commits to a remote repository. Use the git push command to send your changes to the designated remote repository, allowing others to access and integrate your work.",
@@ -63,8 +63,8 @@ export const DUMMY_DATA_QUESTIONS: Question[] = [
     tags: [Tags.commit, Tags.push],
   },
   {
-    id: "Commit and TEshtalhfal",
-    title: "Commit and TEshtalhfal",
+    id: "Checkout and Branching",
+    title: "2. Checkout and Branching",
     hints: [
       "Once your changes are staged, it's time to commit them. Use the git commit command along with a descriptive commit message to document the purpose and nature of your changes. A well-written commit message is essential for clear communication within a development team.",
       "After committing your changes locally, it's time to share them with others by pushing the commits to a remote repository. Use the git push command to send your changes to the designated remote repository, allowing others to access and integrate your work.",
@@ -86,9 +86,9 @@ export const DUMMY_DATA_QUESTIONS: Question[] = [
     learningObjective: {
       objective: "By the end of this lesson, you will understand the importance of Git commit and push, and how they enable you to track and share changes in your codebase effectively.",
       outcomeArray: [
-        "Familiarity with Git Terminology: Students will become reacquainted with essential Git terminology, including \"commit,\" and \"push.\"",
-        "Committing Changes: Students will revisit how to create a commit in Git.",
-        "Pushing Commits: Students will grasp the concept of pushing commits to a remote repository, gaining knowledge about the purpose of remotes and the git push command."
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere leo vitae nisi faucibus, vehicula suscipit ex posuere. Ut malesuada aliquam erat.",
+        "Sed porttitor, enim vitae molestie congue, lectus ex volutpat turpis, tincidunt ultrices velit lorem sed quam.",
+        "Cras nec velit sed urna rhoncus vehicula a eget lacus. Curabitur et tincidunt est. Maecenas non nunc nisl. Proin ac porta risus, non tincidunt sapien."
       ]
     },
     discussion: {
@@ -99,19 +99,17 @@ export const DUMMY_DATA_QUESTIONS: Question[] = [
       ],
       answers: [
         {
-          step: "Step 1: Commit the Changes",
+          step: "Step 1: Test",
           explanation: [
-            "Committing changes in Git is like taking a snapshot of your code at a specific point in time. It allows you to document the changes made and provide a clear description of the modifications",
-            "The -m flag stands for message and is followed by the commit message enclosed in quotes. The commit message is a brief description that explains what changes were made in the commit. It is important to provide a meaningful and descriptive commit message to help you and others understand the purpose of the commit.",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere leo vitae nisi faucibus, vehicula suscipit ex posuere. Ut malesuada aliquam erat. Sed porttitor, enim vitae molestie congue, lectus ex volutpat turpis, tincidunt ultrices velit lorem sed quam. Cras nec velit sed urna rhoncus vehicula a eget lacus. Curabitur et tincidunt est. Maecenas non nunc nisl. Proin ac porta risus, non tincidunt sapien. Mauris vitae quam erat. Nam in efficitur risus. Cras sodales scelerisque felis eget rhoncus."
           ]
         },
         {
-          step: "Step 2: Push the Commits",
+          step: "Step 2: Testing",
           explanation: [
-            "Once you have committed your changes, it's time to push them to a remote repository. Pushing commits means sending your committed changes to a shared repository that can be accessed by others. Use the command git push origin main to push your commits.",
-            "In this command, origin refers to the remote repository's name. You can replace it with the appropriate remote repository name if it differs. main represents the branch you are pushing to, which is typically the main branch in many Git workflows. However, if your repository uses a different main branch name (e.g., master), make sure to replace main with the correct branch name.",
-            "By executing git push origin main, you send your commits to the remote repository, making them available to others who have access to the repository. This allows for collaboration and synchronization of code changes among team members.",
-            "Remember, the git commit -m command and the git push origin main command are essential for documenting and sharing your code changes. By providing meaningful commit messages and regularly pushing your commits to the remote repository, you can effectively track and collaborate on your codebase."
+            "Aenean maximus non nunc ac interdum. Cras in dictum orci, sed ultricies ex. In suscipit elementum sem quis efficitur. Praesent cursus varius lorem sed finibus.",
+            "Praesent laoreet sapien dolor, ut egestas neque dapibus et. Maecenas pretium sit amet ligula at accumsan. Nullam ultrices vel nisl laoreet luctus.",
+            "Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Curabitur vitae auctor purus. Curabitur neque urna, ultrices eget massa eget, semper cursus est. Morbi ac mauris augue."
           ]
         }
       ]
@@ -119,7 +117,7 @@ export const DUMMY_DATA_QUESTIONS: Question[] = [
     // commentIds: [],
     initialGraph: null,
     goalGraph: null,
-    difficulty: Difficulty.EASY,
+    difficulty: Difficulty.MEDIUM,
     tags: [Tags.commit, Tags.push],
   }
 ]

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -1,4 +1,4 @@
-import { Difficulty, Tags } from "../firebase/enums.ts";
+import { Difficulty, Tags } from "../firebase/firebaseEnums.ts";
 import { Graph, Question } from "../models/types.ts";
 
 export const DUMMY_DATA_QUESTIONS: Question[] = [
@@ -30,9 +30,6 @@ export const DUMMY_DATA_QUESTIONS: Question[] = [
         "Pushing Commits: Students will grasp the concept of pushing commits to a remote repository, gaining knowledge about the purpose of remotes and the git push command."
       ]
     },
-    difficulty: Difficulty.EASY,
-    tags: [Tags.commit, Tags.push],
-
     discussion: {
       statement: "To commit and push changes to a Git repository, you need to follow a series of commands. Let's go through each step, and then we'll provide explanations for each command:",
       commands: [
@@ -60,7 +57,9 @@ export const DUMMY_DATA_QUESTIONS: Question[] = [
     },
     // commentIds: [],
     initialGraph: null,
-    goalGraph: null
+    goalGraph: null,
+    difficulty: Difficulty.EASY,
+    tags: [Tags.commit, Tags.push],
   }
 ]
 

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -1,4 +1,4 @@
-import { Difficulty, Tags } from "../firebase/firebaseEnums.ts";
+import { Difficulty, Tags } from "../models/enums.ts";
 import { Graph, Question } from "../models/types.ts";
 
 export const DUMMY_DATA_QUESTIONS: Question[] = [

--- a/src/data/dummyData.ts
+++ b/src/data/dummyData.ts
@@ -1,5 +1,5 @@
+import { Difficulty, Tags } from "../firebase/enums.ts";
 import { Graph, Question } from "../models/types.ts";
-import { Difficulty } from "../firebase/enums.ts";
 
 export const DUMMY_DATA_QUESTIONS: Question[] = [
   {
@@ -30,6 +30,9 @@ export const DUMMY_DATA_QUESTIONS: Question[] = [
         "Pushing Commits: Students will grasp the concept of pushing commits to a remote repository, gaining knowledge about the purpose of remotes and the git push command."
       ]
     },
+    difficulty: Difficulty.EASY,
+    tags: [Tags.commit, Tags.push],
+
     discussion: {
       statement: "To commit and push changes to a Git repository, you need to follow a series of commands. Let's go through each step, and then we'll provide explanations for each command:",
       commands: [
@@ -57,13 +60,7 @@ export const DUMMY_DATA_QUESTIONS: Question[] = [
     },
     // commentIds: [],
     initialGraph: null,
-    goalGraph: null,
-    difficulty: Difficulty.EASY,
-    tags: ["commit", "push"]
-  },
-  {
-    title: "Checkout and Branch",
-    // The rest of the info
+    goalGraph: null
   }
 ]
 
@@ -72,8 +69,8 @@ export const DUMMY_DATA_GRAPHS: Graph[] = [
     name: `${DUMMY_DATA_QUESTIONS[0].title} - Initial Graph`,
     nodes: ["C1", "C2", "C3"],
     edges: [
-      { source: "C1", target: "C2" },
-      { source: "C1", target: "C3" }
+      {source: "C1", target: "C2"},
+      {source: "C1", target: "C3"}
     ],
     headNode: "C1"
   },
@@ -81,8 +78,8 @@ export const DUMMY_DATA_GRAPHS: Graph[] = [
     name: `${DUMMY_DATA_QUESTIONS[0].title} - Goal Graph`,
     nodes: ["C1", "C2", "C3"],
     edges: [
-      { source: "C1", target: "C2" },
-      { source: "C1", target: "C3" }
+      {source: "C1", target: "C2"},
+      {source: "C1", target: "C3"}
     ],
     headNode: "C1"
   }

--- a/src/firebase/db/initDb.ts
+++ b/src/firebase/db/initDb.ts
@@ -6,7 +6,7 @@ import {
   terminate
 } from "firebase/firestore";
 import { firestore } from "../firebase.ts";
-import { Collection } from "../enums.ts";
+import { Collection } from "../firebaseEnums.ts";
 import { DUMMY_DATA_GRAPHS } from "../../data/dummyData.ts";
 import { storeDocument } from "../firestoreUtils.ts";
 

--- a/src/firebase/enums.ts
+++ b/src/firebase/enums.ts
@@ -1,3 +1,6 @@
+import * as Colors from "@mui/material/colors"
+import { Tag } from "../models/types";
+
 /**
  * Firestore collection names
  */
@@ -12,4 +15,15 @@ export enum Difficulty {
   EASY = "EASY",
   MEDIUM = "MEDIUM",
   HARD = "HARD",
+}
+
+export const Tags = {
+  commit: {
+    name: "commit",
+    color: Colors.purple[400],
+  } as Tag,
+  push: {
+    name: "push",
+    color: Colors.green[600],
+  } as Tag
 }

--- a/src/firebase/enums.ts
+++ b/src/firebase/enums.ts
@@ -2,8 +2,14 @@
  * Firestore collection names
  */
 export enum Collection {
-    USERS = "users",
-    COMMENTS = "comments",
-    QUESTIONS = "questions",
-    GRAPHS = "graphs",
+  USERS = "users",
+  COMMENTS = "comments",
+  QUESTIONS = "questions",
+  GRAPHS = "graphs",
+}
+
+export enum Difficulty {
+  EASY = "EASY",
+  MEDIUM = "MEDIUM",
+  HARD = "HARD",
 }

--- a/src/firebase/firebaseEnums.ts
+++ b/src/firebase/firebaseEnums.ts
@@ -1,0 +1,9 @@
+/**
+ * Firestore collection names
+ */
+export enum Collection {
+  USERS = "users",
+  COMMENTS = "comments",
+  QUESTIONS = "questions",
+  GRAPHS = "graphs",
+}

--- a/src/firebase/firestoreUtils.ts
+++ b/src/firebase/firestoreUtils.ts
@@ -1,7 +1,7 @@
 import { GeneralObject } from "../models/types.ts";
 import { collection, doc, getDoc, getDocs, setDoc } from "firebase/firestore";
 import { firestore } from "./firebase.ts";
-import { Collection } from "./enums.ts";
+import { Collection } from "./firebaseEnums.ts";
 
 /**
  * Store the object (or document in Firestore) into the database
@@ -10,7 +10,7 @@ import { Collection } from "./enums.ts";
  * @param object Object to store
  */
 export async function storeDocument(collectionName: Collection, object: GeneralObject): Promise<void> {
-  const {id, ...data} = object;
+  const { id, ...data } = object;
   let docRef;
 
   // If ID is provided, then update the document

--- a/src/firebase/firestoreUtils.ts
+++ b/src/firebase/firestoreUtils.ts
@@ -1,5 +1,5 @@
 import { GeneralObject } from "../models/types.ts";
-import { collection, doc, getDocs, setDoc } from "firebase/firestore";
+import { collection, doc, getDoc, getDocs, setDoc } from "firebase/firestore";
 import { firestore } from "./firebase.ts";
 import { Collection } from "./enums.ts";
 
@@ -38,4 +38,17 @@ export async function getCollection<T extends GeneralObject>(collectionName: str
 
     return data;
   });
+}
+
+/**
+ * Check if the document exists in the database
+ *
+ * @param collectionName Collection name
+ * @param id Document ID
+ */
+export async function isDocumentExists(collectionName: Collection, id: string): Promise<boolean> {
+  const docRef = doc(firestore, collectionName, id);
+  const docSnap = await getDoc(docRef);
+
+  return docSnap.exists();
 }

--- a/src/hooks/useLocalStorage.tsx
+++ b/src/hooks/useLocalStorage.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+export function useLocalStorage(key: string, initialValue = null) {
+  const [value, setValue] = useState(() => {
+    try {
+      const data = window.localStorage.getItem(key);
+      return data ? JSON.parse(data) : initialValue;
+    } catch {
+      return initialValue;
+    }
+  });
+  
+  useEffect(() => {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  }, [value, setValue]);
+
+  return [value, setValue];
+}

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -15,5 +15,13 @@ export const Tags = {
   push: {
     name: "push",
     color: Colors.green[600],
+  } as Tag,
+  checkout: {
+    name: "checkout",
+    color: Colors.blue[700],
+  } as Tag,
+  branch: {
+    name: "branch",
+    color: Colors.cyan[600],
   } as Tag
 }

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -1,15 +1,5 @@
 import * as Colors from "@mui/material/colors"
-import { Tag } from "../models/types";
-
-/**
- * Firestore collection names
- */
-export enum Collection {
-  USERS = "users",
-  COMMENTS = "comments",
-  QUESTIONS = "questions",
-  GRAPHS = "graphs",
-}
+import { Tag } from "./types.ts";
 
 export enum Difficulty {
   EASY = "EASY",

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,5 +1,5 @@
 import { DocumentReference } from "firebase/firestore";
-import { Difficulty, Tags } from "../firebase/firebaseEnums.ts";
+import { Difficulty } from "./enums";
 
 export interface GeneralObject {
   id?: string;

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,5 +1,5 @@
 import { DocumentReference } from "firebase/firestore";
-import { Difficulty } from "../firebase/enums.ts";
+import { Difficulty, Tags } from "../firebase/enums.ts";
 
 export interface GeneralObject {
   id?: string;
@@ -54,7 +54,7 @@ export interface Question extends GeneralObject {
   initialGraph: Graph | null; // Reference to Graph
   goalGraph: Graph | null; // Reference to Graph
   difficulty: Difficulty;
-  tags: string[];
+  tags: Tag[];
 }
 
 export interface Node {
@@ -72,4 +72,9 @@ export interface Graph extends GeneralObject {
   nodes: Node[];
   edges: Edge[];
   headNode: string | null;
+}
+
+export interface Tag {
+  name: string;
+  color: string;
 }

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,4 +1,5 @@
 import { DocumentReference } from "firebase/firestore";
+import { Difficulty } from "../firebase/enums.ts";
 
 export interface GeneralObject {
   id?: string;
@@ -52,6 +53,8 @@ export interface Question extends GeneralObject {
   // commentIds: DocumentReference[];  // Reference to Comment
   initialGraph: Graph | null; // Reference to Graph
   goalGraph: Graph | null; // Reference to Graph
+  difficulty: Difficulty;
+  tags: string[];
 }
 
 export interface Node {

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,5 +1,5 @@
 import { DocumentReference } from "firebase/firestore";
-import { Difficulty, Tags } from "../firebase/enums.ts";
+import { Difficulty, Tags } from "../firebase/firebaseEnums.ts";
 
 export interface GeneralObject {
   id?: string;
@@ -57,6 +57,11 @@ export interface Question extends GeneralObject {
   tags: Tag[];
 }
 
+export interface Tag {
+  name: string;
+  color: string;
+}
+
 export interface Node {
   name: string;
   branch: string;
@@ -72,9 +77,4 @@ export interface Graph extends GeneralObject {
   nodes: Node[];
   edges: Edge[];
   headNode: string | null;
-}
-
-export interface Tag {
-  name: string;
-  color: string;
 }

--- a/src/pages/LevelSelectPage/LevelCard.module.css
+++ b/src/pages/LevelSelectPage/LevelCard.module.css
@@ -1,0 +1,9 @@
+.container {
+  margin-bottom: 2;
+  border: 2px solid transparent;
+}
+
+.selected {
+  border-color: white;
+  box-sizing: content-box;
+}

--- a/src/pages/LevelSelectPage/LevelCard.module.css
+++ b/src/pages/LevelSelectPage/LevelCard.module.css
@@ -1,9 +1,9 @@
 .container {
-  margin-bottom: 2;
+  margin-bottom: 8px;
   border: 2px solid transparent;
 }
 
 .selected {
-  border-color: white;
+  border-color: #9985EA;
   box-sizing: content-box;
 }

--- a/src/pages/LevelSelectPage/LevelCard.tsx
+++ b/src/pages/LevelSelectPage/LevelCard.tsx
@@ -4,6 +4,7 @@ import StarIcon from '@mui/icons-material/Star';
 import { ReactElement, useState } from "react";
 import { yellow } from "@mui/material/colors";
 import Frame from "../../components/Frame";
+import styles from "./LevelCard.module.css";
 
 const starIconStyle = {
   fontSize: 30,
@@ -14,11 +15,12 @@ interface Props {
   level: string
   difficulty: string
   tags?: ReactElement[]
+  selected: boolean
+  onClick: () => void
 }
 
-export default function LevelCard({level, difficulty, tags}: Props) {
+export default function LevelCard({level, difficulty, tags, selected, onClick}: Props) {
 
-  const [isCompleted, setCompleted] = useState(false);
   const [starred, setStarred] = useState(false);
 
   function toggleStarred() {
@@ -26,9 +28,7 @@ export default function LevelCard({level, difficulty, tags}: Props) {
   }
 
   return (
-    <Frame sx={{
-      marginBottom: 2
-    }}>
+    <Frame onClick={onClick} className={`${styles.container} ${selected ? styles.selected : ""}`}>
       <Stack direction="row" sx={{
         display: "flex",
         position: "relative",

--- a/src/pages/LevelSelectPage/LevelCard.tsx
+++ b/src/pages/LevelSelectPage/LevelCard.tsx
@@ -1,31 +1,20 @@
 import { Box, Stack, Typography } from "@mui/material";
-import StarBorderIcon from '@mui/icons-material/StarBorder';
-import StarIcon from '@mui/icons-material/Star';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { ReactElement, useState } from "react";
-import { yellow } from "@mui/material/colors";
+import { green } from "@mui/material/colors";
 import Frame from "../../components/Frame";
 import styles from "./LevelCard.module.css";
-
-const starIconStyle = {
-  fontSize: 30,
-  color: yellow[600]
-}
 
 interface Props {
   level: string
   difficulty: string
   tags?: ReactElement[]
   selected: boolean
+  completed?: boolean
   onClick: () => void
 }
 
-export default function LevelCard({level, difficulty, tags, selected, onClick}: Props) {
-
-  const [starred, setStarred] = useState(false);
-
-  function toggleStarred() {
-    setStarred(!starred);
-  }
+export default function LevelCard({level, difficulty, tags, selected, completed=false, onClick}: Props) {
 
   return (
     <Frame onClick={onClick} className={`${styles.container} ${selected ? styles.selected : ""}`}>
@@ -48,12 +37,15 @@ export default function LevelCard({level, difficulty, tags, selected, onClick}: 
           </Stack>
         </Stack>
 
-        <Box onClick={toggleStarred} sx={{
+        <Box sx={{
           position: "absolute",
           right: 0
-        }}>{starred ? 
-          <StarBorderIcon sx={starIconStyle}/> :
-          <StarIcon sx={starIconStyle} />}
+        }}>{completed &&
+          <CheckCircleIcon sx={{
+            fontSize: 30,
+            color: green[500]
+          }}/>
+        }
         </Box>
         
         

--- a/src/pages/LevelSelectPage/LevelCardList.tsx
+++ b/src/pages/LevelSelectPage/LevelCardList.tsx
@@ -1,0 +1,30 @@
+import { Stack } from "@mui/material";
+import { Question } from "../../models/types";
+import LevelCard from "./LevelCard";
+import Tag from "../../components/Tag";
+
+interface Props {
+  questions: Question[]
+}
+
+export default function LevelCardList({questions}: Props) {
+  return (
+    <Stack direction="column">
+      {questions.map((question, index) => (
+        <LevelCard
+          key={index}
+          level={`${index + 1}. ${question.title}`}
+          difficulty={question.difficulty}
+          
+          tags={question.tags.map((tag, index) => {
+            return (
+              <Tag key={index} color={tag.color}>
+                {tag.name}
+              </Tag>
+            );
+          })}
+        />  
+      ))}
+    </Stack>
+  );
+}

--- a/src/pages/LevelSelectPage/LevelCardList.tsx
+++ b/src/pages/LevelSelectPage/LevelCardList.tsx
@@ -22,7 +22,7 @@ export default function LevelCardList({questions}: Props) {
       {questions.map((question, index) => (
         <LevelCard
           key={index}
-          level={`${index + 1}. ${question.title}`}
+          level={`${question.title}`}
           difficulty={question.difficulty}
           selected={question.id == selectedQuestion.id}
           onClick={() => handleClick(question)}

--- a/src/pages/LevelSelectPage/LevelCardList.tsx
+++ b/src/pages/LevelSelectPage/LevelCardList.tsx
@@ -2,7 +2,8 @@ import { Stack } from "@mui/material";
 import { Question } from "../../models/types";
 import LevelCard from "./LevelCard";
 import Tag from "../../components/Tag";
-import { useLocalStorage } from "../../hooks/useLocalStorage";
+import { useContext } from "react";
+import { LevelContext } from "../../context/LevelContext";
 
 interface Props {
   questions: Question[]
@@ -10,10 +11,10 @@ interface Props {
 
 export default function LevelCardList({questions}: Props) {
 
-  const [selectedQuestionId, setQuestionId] = useLocalStorage("selectedQuestionId");
+  const { selectedQuestion, setQuestion } = useContext(LevelContext);
 
   function handleClick(question: Question) {
-    setQuestionId(question.id);
+    setQuestion(question);
   }
 
   return (
@@ -23,7 +24,7 @@ export default function LevelCardList({questions}: Props) {
           key={index}
           level={`${index + 1}. ${question.title}`}
           difficulty={question.difficulty}
-          selected={question.id == selectedQuestionId}
+          selected={question.id == selectedQuestion.id}
           onClick={() => handleClick(question)}
 
           tags={question.tags.map((tag, index) => {

--- a/src/pages/LevelSelectPage/LevelCardList.tsx
+++ b/src/pages/LevelSelectPage/LevelCardList.tsx
@@ -25,6 +25,9 @@ export default function LevelCardList({questions}: Props) {
           level={`${question.title}`}
           difficulty={question.difficulty}
           selected={question.id == selectedQuestion.id}
+
+          // TODO: check current user's completed questions and mark accordingly
+          completed={true}
           onClick={() => handleClick(question)}
 
           tags={question.tags.map((tag, index) => {

--- a/src/pages/LevelSelectPage/LevelCardList.tsx
+++ b/src/pages/LevelSelectPage/LevelCardList.tsx
@@ -2,12 +2,20 @@ import { Stack } from "@mui/material";
 import { Question } from "../../models/types";
 import LevelCard from "./LevelCard";
 import Tag from "../../components/Tag";
+import { useLocalStorage } from "../../hooks/useLocalStorage";
 
 interface Props {
   questions: Question[]
 }
 
 export default function LevelCardList({questions}: Props) {
+
+  const [selectedQuestionId, setQuestionId] = useLocalStorage("selectedQuestionId");
+
+  function handleClick(question: Question) {
+    setQuestionId(question.id);
+  }
+
   return (
     <Stack direction="column">
       {questions.map((question, index) => (
@@ -15,7 +23,9 @@ export default function LevelCardList({questions}: Props) {
           key={index}
           level={`${index + 1}. ${question.title}`}
           difficulty={question.difficulty}
-          
+          selected={question.id == selectedQuestionId}
+          onClick={() => handleClick(question)}
+
           tags={question.tags.map((tag, index) => {
             return (
               <Tag key={index} color={tag.color}>

--- a/src/pages/LevelSelectPage/LevelDetailsPanel.module.css
+++ b/src/pages/LevelSelectPage/LevelDetailsPanel.module.css
@@ -1,0 +1,26 @@
+.unselected{
+  width:50%;
+  font-size:16pt; 
+  font-weight:bold;
+  background-color: #3E3E3E;
+  color: #B3B3B3;
+}
+
+.selected{
+  width:50%;
+  font-size:16pt; 
+  font-weight:bold;
+  background-color: #7A4CC5;
+}
+
+.unselected:hover,
+.selected:hover {
+  border-color: #fff;
+}
+
+.unselected:focus,
+.unselected:focus-visible,
+.selected:focus,
+.selected:focus-visible {
+  outline: none;
+}

--- a/src/pages/LevelSelectPage/LevelDetailsPanel.tsx
+++ b/src/pages/LevelSelectPage/LevelDetailsPanel.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+import Frame from "../../components/Frame";
+import LevelDescription from "../../components/LevelDescription/LevelDescription";
+import LevelDiscussion from "../../components/LevelDiscussion/LevelDiscussion";
+import { Question } from "../../models/types";
+import styles from "./LevelDetailsPanel.module.css";
+
+interface Props {
+  question: Question | undefined;
+}
+
+export default function LevelDetailsPanel({question}: Props) {
+
+  const location = useLocation();
+  const [selected, setSelected] = React.useState(
+    location.state?.tab === "discussion" ? false : true
+  );
+  return (
+    <Frame
+      sx={{
+        height: 1,
+      }}
+    >
+      <div>
+        <span>
+          <button
+            className={selected ? styles.selected : styles.unselected}
+            onClick={() => {
+              setSelected(true);
+            }}
+          >
+            DESCRIPTION
+          </button>
+          <button
+            className={!selected ? styles.selected : styles.unselected}
+            onClick={() => {
+              setSelected(false);
+            }}
+          >
+            DISCUSSION
+          </button>
+        </span>
+        {/* Place description/ discussion component here */}
+        {selected ? (
+          <LevelDescription title="Description" content="Content"/>
+        ) : question ? (
+          <LevelDiscussion question={question}/>
+        ) : (
+          <div>Loading...</div>
+        )}
+      </div>
+    </Frame>
+  );
+}

--- a/src/pages/LevelSelectPage/LevelDetailsPanel.tsx
+++ b/src/pages/LevelSelectPage/LevelDetailsPanel.tsx
@@ -1,16 +1,15 @@
-import React from "react";
+import React, { useContext } from "react";
 import { useLocation } from "react-router-dom";
 import Frame from "../../components/Frame";
 import LevelDescription from "../../components/LevelDescription/LevelDescription";
 import LevelDiscussion from "../../components/LevelDiscussion/LevelDiscussion";
 import { Question } from "../../models/types";
 import styles from "./LevelDetailsPanel.module.css";
+import { LevelContext } from "../../context/LevelContext";
 
-interface Props {
-  question: Question;
-}
+export default function LevelDetailsPanel() {
 
-export default function LevelDetailsPanel({question}: Props) {
+  const { selectedQuestion } = useContext(LevelContext);
 
   const location = useLocation();
   const [selected, setSelected] = React.useState(
@@ -41,10 +40,10 @@ export default function LevelDetailsPanel({question}: Props) {
             DISCUSSION
           </button>
         </span>
-        
+
         {selected ? (
           <LevelDescription />
-        ) : question ? (
+        ) : selectedQuestion ? (
           <LevelDiscussion />
         ) : (
           <div>Loading...</div>

--- a/src/pages/LevelSelectPage/LevelDetailsPanel.tsx
+++ b/src/pages/LevelSelectPage/LevelDetailsPanel.tsx
@@ -7,7 +7,7 @@ import { Question } from "../../models/types";
 import styles from "./LevelDetailsPanel.module.css";
 
 interface Props {
-  question: Question | undefined;
+  question: Question;
 }
 
 export default function LevelDetailsPanel({question}: Props) {
@@ -41,11 +41,11 @@ export default function LevelDetailsPanel({question}: Props) {
             DISCUSSION
           </button>
         </span>
-        {/* Place description/ discussion component here */}
+        
         {selected ? (
-          <LevelDescription title="Description" content="Content"/>
+          <LevelDescription />
         ) : question ? (
-          <LevelDiscussion question={question}/>
+          <LevelDiscussion />
         ) : (
           <div>Loading...</div>
         )}

--- a/src/pages/LevelSelectPage/LevelSelectPage.module.css
+++ b/src/pages/LevelSelectPage/LevelSelectPage.module.css
@@ -1,30 +1,3 @@
-.unselected{
-  width:50%;
-  font-size:16pt; 
-  font-weight:bold;
-  background-color: #3E3E3E;
-  color: #B3B3B3;
-}
-
-.selected{
-  width:50%;
-  font-size:16pt; 
-  font-weight:bold;
-  background-color: #7A4CC5;
-}
-
-.unselected:hover,
-.selected:hover {
-  border-color: #fff;
-}
-
-.unselected:focus,
-.unselected:focus-visible,
-.selected:focus,
-.selected:focus-visible {
-  outline: none;
-}
-
 .mainGrid{
   position: absolute;
   top: 100px;

--- a/src/pages/LevelSelectPage/LevelSelectPage.tsx
+++ b/src/pages/LevelSelectPage/LevelSelectPage.tsx
@@ -1,25 +1,18 @@
-import * as React from "react";
-import { green, purple } from "@mui/material/colors";
-import LevelCard from "./LevelCard";
-import Tag from "../../components/Tag";
-import { Grid, Stack } from "@mui/material";
-import Frame from "../../components/Frame";
+import { Grid } from "@mui/material";
 import styles from "./LevelSelectPage.module.css";
 import NavigationBar from "../../components/NavigationBar/NavigationBar";
-import LevelDescription from "../../components/LevelDescription/LevelDescription";
-import LevelDiscussion from "../../components/LevelDiscussion/LevelDiscussion.tsx";
 import { DUMMY_DATA_QUESTIONS } from "../../data/dummyData.ts";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Question } from "../../models/types.ts";
-import { useLocation } from "react-router-dom";
 import LevelCardList from "./LevelCardList.tsx";
 import LevelDetailsPanel from "./LevelDetailsPanel.tsx";
-import { useLocalStorage } from "../../hooks/useLocalStorage.tsx";
+import { LevelContext } from "../../context/LevelContext.tsx";
 
 export default function LevelSelectPage() {
 
   const [allQuestions, setAllQuestions] = useState<Question[]>([]);
-  const [selectedQuestionId, setQuestionId] = useLocalStorage("selectedQuestionId");
+  const { selectedQuestion } = useContext(LevelContext);
+
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
@@ -31,7 +24,6 @@ export default function LevelSelectPage() {
       // setIsLoading(false);
 
       setAllQuestions(DUMMY_DATA_QUESTIONS);
-      setQuestionId(DUMMY_DATA_QUESTIONS[0].id)
     }
 
     init();
@@ -50,7 +42,7 @@ export default function LevelSelectPage() {
           <LevelCardList questions={allQuestions}/>
         </Grid>
         <Grid item xs={8}>
-          <LevelDetailsPanel question={selectedQuestionId}/>
+          <LevelDetailsPanel question={selectedQuestion ? selectedQuestion : DUMMY_DATA_QUESTIONS[0]}/>
         </Grid>
       </Grid>
     </div>

--- a/src/pages/LevelSelectPage/LevelSelectPage.tsx
+++ b/src/pages/LevelSelectPage/LevelSelectPage.tsx
@@ -13,17 +13,6 @@ import { useEffect, useState } from "react";
 import { Question } from "../../models/types.ts";
 import { useLocation } from "react-router-dom";
 
-const tags = [
-  {
-    name: "commit",
-    color: purple[400],
-  },
-  {
-    name: "push",
-    color: green[600],
-  },
-];
-
 export default function LevelSelectPage() {
   const location = useLocation();
   const [selected, setSelected] = React.useState(
@@ -58,28 +47,20 @@ export default function LevelSelectPage() {
       >
         <Grid item xs={4}>
           <Stack direction="column">
-            <LevelCard
-              level="1. Commit and Push"
-              difficulty="Easy"
-              tags={tags.map((tag, index) => {
-                return (
-                  <Tag key={index} color={tag.color}>
-                    {tag.name}
-                  </Tag>
-                );
-              })}
-            />
-            <LevelCard
-              level="2. Checkout and Branch"
-              difficulty="Easy"
-              tags={tags.map((tag, index) => {
-                return (
-                  <Tag key={index} color={tag.color}>
-                    {tag.name}
-                  </Tag>
-                );
-              })}
-            />
+            {allQuestions.map((question, index) => (
+              <LevelCard
+                key={index}
+                level={`${index + 1}. ${question.title}`}
+                difficulty={question.difficulty}
+                tags={question.tags.map((tag, index) => {
+                  return (
+                    <Tag key={index} color={tag.color}>
+                      {tag.name}
+                    </Tag>
+                  );
+                })}
+              />  
+            ))}
           </Stack>
         </Grid>
         <Grid item xs={8}>

--- a/src/pages/LevelSelectPage/LevelSelectPage.tsx
+++ b/src/pages/LevelSelectPage/LevelSelectPage.tsx
@@ -13,14 +13,12 @@ import { useEffect, useState } from "react";
 import { Question } from "../../models/types.ts";
 import { useLocation } from "react-router-dom";
 import LevelCardList from "./LevelCardList.tsx";
+import LevelDetailsPanel from "./LevelDetailsPanel.tsx";
 
 export default function LevelSelectPage() {
-  const location = useLocation();
-  const [selected, setSelected] = React.useState(
-    location.state?.tab === "discussion" ? false : true
-  );
 
   const [allQuestions, setAllQuestions] = useState<Question[]>([]);
+  const [selectedQuestion, setQuestion] = useState<Question>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
@@ -32,6 +30,7 @@ export default function LevelSelectPage() {
       // setIsLoading(false);
 
       setAllQuestions(DUMMY_DATA_QUESTIONS);
+      setQuestion(DUMMY_DATA_QUESTIONS[0])
     }
 
     init();
@@ -50,40 +49,7 @@ export default function LevelSelectPage() {
           <LevelCardList questions={allQuestions}/>
         </Grid>
         <Grid item xs={8}>
-          <Frame
-            sx={{
-              height: 1,
-            }}
-          >
-            <div>
-              <span>
-                <button
-                  className={selected ? styles.selected : styles.unselected}
-                  onClick={() => {
-                    setSelected(true);
-                  }}
-                >
-                  DESCRIPTION
-                </button>
-                <button
-                  className={!selected ? styles.selected : styles.unselected}
-                  onClick={() => {
-                    setSelected(false);
-                  }}
-                >
-                  DISCUSSION
-                </button>
-              </span>
-              {/* Place description/ discussion component here */}
-              {selected ? (
-                <LevelDescription title="Description" content="Content"/>
-              ) : allQuestions[0] ? (
-                <LevelDiscussion question={allQuestions[0]}/>
-              ) : (
-                <div>Loading...</div>
-              )}
-            </div>
-          </Frame>
+          <LevelDetailsPanel question={selectedQuestion}/>
         </Grid>
       </Grid>
     </div>

--- a/src/pages/LevelSelectPage/LevelSelectPage.tsx
+++ b/src/pages/LevelSelectPage/LevelSelectPage.tsx
@@ -12,6 +12,7 @@ import { DUMMY_DATA_QUESTIONS } from "../../data/dummyData.ts";
 import { useEffect, useState } from "react";
 import { Question } from "../../models/types.ts";
 import { useLocation } from "react-router-dom";
+import LevelCardList from "./LevelCardList.tsx";
 
 export default function LevelSelectPage() {
   const location = useLocation();
@@ -46,22 +47,7 @@ export default function LevelSelectPage() {
         sx={{height: 0.85}}
       >
         <Grid item xs={4}>
-          <Stack direction="column">
-            {allQuestions.map((question, index) => (
-              <LevelCard
-                key={index}
-                level={`${index + 1}. ${question.title}`}
-                difficulty={question.difficulty}
-                tags={question.tags.map((tag, index) => {
-                  return (
-                    <Tag key={index} color={tag.color}>
-                      {tag.name}
-                    </Tag>
-                  );
-                })}
-              />  
-            ))}
-          </Stack>
+          <LevelCardList questions={allQuestions}/>
         </Grid>
         <Grid item xs={8}>
           <Frame

--- a/src/pages/LevelSelectPage/LevelSelectPage.tsx
+++ b/src/pages/LevelSelectPage/LevelSelectPage.tsx
@@ -42,7 +42,7 @@ export default function LevelSelectPage() {
           <LevelCardList questions={allQuestions}/>
         </Grid>
         <Grid item xs={8}>
-          <LevelDetailsPanel question={selectedQuestion ? selectedQuestion : DUMMY_DATA_QUESTIONS[0]}/>
+          <LevelDetailsPanel />
         </Grid>
       </Grid>
     </div>

--- a/src/pages/LevelSelectPage/LevelSelectPage.tsx
+++ b/src/pages/LevelSelectPage/LevelSelectPage.tsx
@@ -14,11 +14,12 @@ import { Question } from "../../models/types.ts";
 import { useLocation } from "react-router-dom";
 import LevelCardList from "./LevelCardList.tsx";
 import LevelDetailsPanel from "./LevelDetailsPanel.tsx";
+import { useLocalStorage } from "../../hooks/useLocalStorage.tsx";
 
 export default function LevelSelectPage() {
 
   const [allQuestions, setAllQuestions] = useState<Question[]>([]);
-  const [selectedQuestion, setQuestion] = useState<Question>();
+  const [selectedQuestionId, setQuestionId] = useLocalStorage("selectedQuestionId");
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
@@ -30,7 +31,7 @@ export default function LevelSelectPage() {
       // setIsLoading(false);
 
       setAllQuestions(DUMMY_DATA_QUESTIONS);
-      setQuestion(DUMMY_DATA_QUESTIONS[0])
+      setQuestionId(DUMMY_DATA_QUESTIONS[0].id)
     }
 
     init();
@@ -49,7 +50,7 @@ export default function LevelSelectPage() {
           <LevelCardList questions={allQuestions}/>
         </Grid>
         <Grid item xs={8}>
-          <LevelDetailsPanel question={selectedQuestion}/>
+          <LevelDetailsPanel question={selectedQuestionId}/>
         </Grid>
       </Grid>
     </div>

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -6,7 +6,7 @@ import { signInWithEmailAndPassword, signInWithPopup } from "firebase/auth";
 import GoogleIcon from "@mui/icons-material/Google";
 import styles from "../../pages/SignUpPage/SignUpPage.module.css";
 import { isDocumentExists, storeDocument } from "../../firebase/firestoreUtils.ts";
-import { Collection } from "../../firebase/enums.ts";
+import { Collection } from "../../firebase/firebaseEnums.ts";
 import { User } from "../../models/types.ts";
 
 const LoginPage = () => {
@@ -122,7 +122,7 @@ const LoginPage = () => {
                   onClick={handleGoogleSignin}
                   className={styles["button"]}
                 >
-                  <GoogleIcon className={styles["google-icon"]} /> SIGN IN WITH
+                  <GoogleIcon className={styles["google-icon"]}/> SIGN IN WITH
                   GOOGLE
                 </Button>
               </Grid>

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,18 +1,13 @@
-import {
-  Button,
-  TextField,
-  Typography,
-  Container,
-  Grid,
-  Box,
-} from "@mui/material";
+import { Box, Button, Container, Grid, TextField, Typography, } from "@mui/material";
 import React, { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
-import { auth, firestore, googleProvider } from "../../firebase/firebase";
+import { Link, useNavigate } from "react-router-dom";
+import { auth, googleProvider } from "../../firebase/firebase";
 import { signInWithEmailAndPassword, signInWithPopup } from "firebase/auth";
 import GoogleIcon from "@mui/icons-material/Google";
 import styles from "../../pages/SignUpPage/SignUpPage.module.css";
-import { doc, getDoc, setDoc } from "firebase/firestore";
+import { isDocumentExists, storeDocument } from "../../firebase/firestoreUtils.ts";
+import { Collection } from "../../firebase/enums.ts";
+import { User } from "../../models/types.ts";
 
 const LoginPage = () => {
   const navigate = useNavigate();
@@ -28,21 +23,18 @@ const LoginPage = () => {
         throw new Error("Failed to authenticate user");
       }
 
-      const userDocRef = doc(firestore, "users", user.uid);
-      const userDocSnap = await getDoc(userDocRef);
-
-      if (!userDocSnap.exists()) {
-        const newUser = {
-          email: user.email,
+      if (!(await isDocumentExists(Collection.USERS, user.uid))) {
+        const newUser: User = {
+          id: user.uid,
           name: "",
+          email: user.email!,
           expProgress: "0",
           level: "1",
           profileImg: "",
           completedQuestions: [],
           attemptedQuestions: [],
         };
-
-        await setDoc(userDocRef, newUser);
+        await storeDocument(Collection.USERS, newUser);
       }
 
       navigate("/home");
@@ -55,21 +47,18 @@ const LoginPage = () => {
     try {
       const { user } = await signInWithPopup(auth, googleProvider);
 
-      const userDocRef = doc(firestore, "users", user.uid);
-      const userDocSnap = await getDoc(userDocRef);
-
-      if (!userDocSnap.exists()) {
-        const newUser = {
-          email: user.email,
+      if (!(await isDocumentExists(Collection.USERS, user.uid))) {
+        const newUser: User = {
+          id: user.uid,
           name: "",
+          email: user.email!,
           expProgress: "0",
           level: "1",
           profileImg: "",
           completedQuestions: [],
           attemptedQuestions: [],
         };
-
-        await setDoc(userDocRef, newUser);
+        await storeDocument(Collection.USERS, newUser);
       }
 
       navigate("/home");
@@ -79,8 +68,8 @@ const LoginPage = () => {
   };
 
   return (
-    <Box sx={{display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100vh'}}>
-      <Container component="main" maxWidth="xs" sx={{textAlign: 'center'}}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100vh' }}>
+      <Container component="main" maxWidth="xs" sx={{ textAlign: 'center' }}>
         <Box className={styles["input-container"]}>
           <Typography variant="h1" className={styles["heading"]}>
             {" "}

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -7,7 +7,7 @@ import GoogleIcon from "@mui/icons-material/Google";
 import styles from "./SignUpPage.module.css";
 import { User } from "../../models/types";
 import { isDocumentExists, storeDocument } from "../../firebase/firestoreUtils";
-import { Collection } from "../../firebase/enums";
+import { Collection } from "../../firebase/firebaseEnums.ts";
 
 const Signuppage = () => {
   const navigate = useNavigate();
@@ -150,7 +150,7 @@ const Signuppage = () => {
                   onClick={handleGoogleSignup}
                   className={styles["button"]}
                 >
-                  <GoogleIcon className={styles["google-icon"]} /> SIGN UP WITH
+                  <GoogleIcon className={styles["google-icon"]}/> SIGN UP WITH
                   GOOGLE
                 </Button>
               </Grid>

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -1,20 +1,12 @@
-import {
-  TextField,
-  Typography,
-  Button,
-  Container,
-  Grid,
-  Box,
-} from "@mui/material";
+import { Box, Button, Container, Grid, TextField, Typography, } from "@mui/material";
 import { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
-import { auth, firestore, googleProvider } from "../../firebase/firebase";
+import { Link, useNavigate } from "react-router-dom";
+import { auth, googleProvider } from "../../firebase/firebase";
 import { createUserWithEmailAndPassword, signInWithPopup } from "firebase/auth";
 import GoogleIcon from "@mui/icons-material/Google";
 import styles from "./SignUpPage.module.css";
-import { doc, getDoc, setDoc } from "firebase/firestore";
 import { User } from "../../models/types";
-import { storeDocument } from "../../firebase/firestoreUtils";
+import { isDocumentExists, storeDocument } from "../../firebase/firestoreUtils";
 import { Collection } from "../../firebase/enums";
 
 const Signuppage = () => {
@@ -36,8 +28,8 @@ const Signuppage = () => {
         password
       );
       const user = userCredential.user;
-      const userDoc = doc(firestore, "users", user.uid);
       const newUser: User = {
+        id: user.uid,
         name: "New User",
         email: email,
         expProgress: "0",
@@ -46,7 +38,8 @@ const Signuppage = () => {
         completedQuestions: [],
         attemptedQuestions: [],
       };
-      await setDoc(userDoc, newUser);
+      await storeDocument(Collection.USERS, newUser);
+
       navigate("/home");
     } catch (error: any) {
       alert(error.message);
@@ -57,22 +50,22 @@ const Signuppage = () => {
     try {
       const userCredential = await signInWithPopup(auth, googleProvider);
       const user = userCredential.user;
-      const newUser: User = {
-        name: "New User",
-        email: email,
-        expProgress: "0",
-        level: "1",
-        profileImg: "",
-        completedQuestions: [],
-        attemptedQuestions: [],
-      };
 
-      const userDoc = doc(firestore, "users", user.uid);
-
-      if ((await getDoc(userDoc)).exists()) {
+      if (await isDocumentExists(Collection.USERS, user.uid)) {
         navigate("/home");
       } else {
+        const newUser: User = {
+          id: user.uid,
+          name: "New User",
+          email: email,
+          expProgress: "0",
+          level: "1",
+          profileImg: "",
+          completedQuestions: [],
+          attemptedQuestions: [],
+        };
         await storeDocument(Collection.USERS, newUser);
+
         navigate("/home");
       }
     } catch (error: any) {
@@ -81,8 +74,8 @@ const Signuppage = () => {
   };
 
   return (
-    <Box sx={{display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100vh'}}>
-      <Container component="main" maxWidth="xs" sx={{textAlign: 'center'}}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100vh' }}>
+      <Container component="main" maxWidth="xs" sx={{ textAlign: 'center' }}>
         <Grid
           container
           direction="column"


### PR DESCRIPTION
## Description

Resolves #74 - levels can now be selected using card views, and updates information on details panel (right side of screen), e.g: title, description, model answers

This PR does the following:

- [x] Add LevelContext for storing currently selected question across multiple components
- [x] Add dummy data (lorem ipsum) for 2. Checkout and Branching
- [x] Add (unused) useLocalStorage hook
- [x] Add tags enum for level select cards
- [x] Extract level card list and details panel into separate components out of LevelSelectPage

TODO: link comments section with firebase w/ @Bac0nEater #69 
