### PR TITLE
added modal explaining hints and correct mode only toggle

### DIFF
--- a/src/HelpBar/DirectedModeSwitch.tsx
+++ b/src/HelpBar/DirectedModeSwitch.tsx
@@ -15,7 +15,7 @@ export default function DirectedModeSwitch({onToggle}: helpBarProp) {
     }
 
     return(
-        <Tooltip title= {checked ? "Scaffolded mode (Correct commands only)" : "Free mode"}>
+        <Tooltip title= {checked ? "Correct commands only mode" : "Free mode"}>
             <Switch sx={{
                 borderRadius: 2,
                 "& .MuiSwitch-switchBase.Mui-checked": {

--- a/src/components/QuestionStartModal/QuestionStartModal.module.css
+++ b/src/components/QuestionStartModal/QuestionStartModal.module.css
@@ -1,0 +1,44 @@
+.modal-container {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 400px;
+    background-color: #343434;
+    border: 2px solid #000;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  .modal-title {
+    margin-bottom: 10px;
+    font-weight: bold;
+    color: #fff;
+  }
+
+  .modal-question-title{
+    font-size: 24px;
+    margin-bottom: 10px;
+    font-weight: bold;
+    color: #ab47bc;
+  }
+
+  .modal-subtitle{
+    margin-bottom: 10px;
+    color: #ab47bc;
+  }
+  
+  .modal-text {
+    margin-bottom: 10px;
+    color: #fff;
+    text-align: center;
+  }
+
+  .modal-key-commands {
+    color: #fff;
+    font-size: 10pt;
+  }
+  

--- a/src/components/QuestionStartModal/QuestionStartModal.tsx
+++ b/src/components/QuestionStartModal/QuestionStartModal.tsx
@@ -1,0 +1,42 @@
+import Modal from "@mui/material/Modal";
+import { Box } from "@mui/material";
+import Typography from "@mui/material/Typography";
+import styles from "./QuestionStartModal.module.css";
+import GreenButton from "../GreenButton/GreenButton";
+
+export default function QuestionStartModal({ onClose }: { onClose: () => void }) {
+
+  const handleCloseModal = () => {
+    onClose();
+  };
+
+  return (
+    <Modal open={true} onClose={handleCloseModal}>
+      <Box className={styles["modal-container"]}>
+        <Typography variant="h4" className={styles["modal-question-title"]}>
+          If you're stuck...
+        </Typography>
+        <br />
+        <Typography variant="body1" className={styles["modal-text"]}>
+          At the top right of the screen you will find a hint button and below it a switch that toggles correct commands only mode.
+        </Typography>
+        <br />
+        <Typography variant="h4" className={styles["modal-subtitle"]}>
+        When in correct commands only mode:
+        </Typography>
+        <ul className={styles["modal-key-commands"]}>
+          <li>Incorrect commands will be printed red and will not update the graph</li>
+          <li>Correct command will be printed green and will update the graph</li>
+        </ul>
+        <Typography></Typography>
+        <Typography variant="h4" className={styles["modal-subtitle"]}>
+        The hint button
+        </Typography>
+        <ul className={styles["modal-key-commands"]}>
+          <li>Hover over to get a hint and press to cycle through hints</li>
+        </ul>
+        <GreenButton onClick={handleCloseModal}>Begin Question</GreenButton>
+      </Box>
+    </Modal>
+  );
+}

--- a/src/pages/QuestionPage/QuestionPage.tsx
+++ b/src/pages/QuestionPage/QuestionPage.tsx
@@ -13,6 +13,7 @@ import {
   gitCommitPushEdgesGoal,
 } from "../../components/GitGraph/git-commit-push-nodes-edges";
 import { LevelContext } from "../../context/LevelContext";
+import QuestionStartModal from "../../components/QuestionStartModal/QuestionStartModal";
 
 const QuestionPage = () => {
 
@@ -20,6 +21,7 @@ const QuestionPage = () => {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isComplete, setComplete] = useState(false);
+  const [isOpened, setOpened] = useState(true);
 
   const handleModalOpen = () => {
     setIsModalOpen(true);
@@ -27,6 +29,10 @@ const QuestionPage = () => {
 
   const handleModalClose = () => {
     setIsModalOpen(false);
+  };
+
+  const handleFirstModalClose = () => {
+    setOpened(false);
   };
 
   return(
@@ -67,6 +73,7 @@ const QuestionPage = () => {
         </Grid>
       </div>
       {isModalOpen && <QuestionEndModal onClose={handleModalClose} />}
+      {isOpened && <QuestionStartModal onClose={handleFirstModalClose} />}
     </div>
   );
 };


### PR DESCRIPTION
## Description

Resolves #96 

This PR does the following:

- Adds a modal that opens on start up to inform users about the different help tools
- Removes the technical scaffolding name
