### PR TITLE
fix: prevent headless from being branch

### DIFF
--- a/src/components/Terminal/index.tsx
+++ b/src/components/Terminal/index.tsx
@@ -94,6 +94,10 @@ export default function Terminal({
           setEdges([...edges, newEdge]);
 
           setHEAD(newNode);
+
+          if (branch == 'HEADLESS')
+            break;
+          
           setBranchHEADS(new Map(branchHEADS).set(branch, newNode));
 
           const newBranchNodes = new Map<string, string[]>(branchNodes);


### PR DESCRIPTION
## Description

Resolves #130 

This PR does the following:

- [x] Prevent headless from acting like branch
